### PR TITLE
chore: update ttl to 1 min

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -3,7 +3,7 @@ use worker::*;
 
 // Constants for better maintainability
 const CLOUDFLARE_API_BASE: &str = "https://api.cloudflare.com/client/v4";
-const DNS_TTL: u32 = 1;
+const DNS_TTL: u32 = 60;
 const CONTENT_TYPE_JSON: &str = "application/json";
 
 /// DNS record types supported by this implementation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default TTL (time-to-live) value for DNS records from 1 to 60 seconds when creating or updating records via the Cloudflare integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->